### PR TITLE
Fixed conversion issues

### DIFF
--- a/src/xrlToXfdf/utils.js
+++ b/src/xrlToXfdf/utils.js
@@ -198,13 +198,22 @@ const getCreationTime = (creationtimeAttr) => {
     }
     return str;
   };
-  
+    
   let dateC = new Date(creationtimeAttr.nodeValue * 1000);
 
-  let monthC = dateC.getMonth();
+  let monthC = (dateC.getMonth() + 1) + "";
   if (monthC.toString().length === 1) monthC = "0" + monthC;
-
-  let creationdateFormated = "D:" + dateC.getFullYear() + monthC + dateC.getDay() + dateC.getHours() + dateC.getMinutes() + dateC.getSeconds();// + "-08'00'";
+  else  monthC +="";
+	
+  let dayC = dateC.getDate()+"";
+  if (dayC.toString().length === 1) dayC = "0" + dayC;
+  let hourC = dateC.getHours()+"";
+  if (hourC.toString().length === 1) hourC = "0" + hourC;
+  let minC = dateC.getMinutes()+"";
+  if (minC.toString().length === 1) minC = "0" + minC;
+  let secC = dateC.getSeconds()+"";
+  if (secC.toString().length === 1) secC = "0" + secC;
+  let creationdateFormated = "D:" + dateC.getFullYear() + monthC + dayC + hourC + minC + secC;// + "-08'00'";
     
   let offset = dateC.getTimezoneOffset();
   if (offset === 0) {


### PR DESCRIPTION
Fixed the following issues:
1. Incorrect date conversions for time attributes of Brava annotations.
2. Incorrect Text location when there is only 1 text in the markups in the Brava markup.
3. Fix issues with additional carriage returns on text after conversion.
4. Extend the width of the freetext if there is only 1 line of text.